### PR TITLE
Add fail for WIP commits going to master

### DIFF
--- a/gnitpick.py
+++ b/gnitpick.py
@@ -235,13 +235,24 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if not args.target_branch:
-        # Default value
-        target_branch = 'master'
+    target_branch = args.target_branch if args.target_branch else "master"
 
     if not args.target_repository:
         # Default value
         target_repository = 'origin'
+        # check that the target branch exists in remote
+        try:
+            subprocess.check_call([
+                "git",
+                "ls-remote",
+                "--exit-code",
+                "--heads",
+                "origin",
+                target_branch
+            ])
+        except subprocess.CalledProcessError:
+            print(f"Target branch {target_branch} does not exist!")
+            exit(1)
     else:
         print(f'Checking against target repository "{args.target_repository}"')
 
@@ -327,7 +338,6 @@ if __name__ == '__main__':
         cmd = ['git', 'rev-list', '--max-count=100', git_rev]
         subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError as e:
-        print(e.returncode)
         if e.returncode == 128:
             print(
                 f"Cannot compare {git_rev}, attempting to fetch more commits")

--- a/gnitpick.py
+++ b/gnitpick.py
@@ -180,6 +180,20 @@ class Gnitpick():
         if title[0:14] == "Merge branch '":
             self._add_fail("Merge request includes merges by itself")
 
+        main_branches = ["main", "master"]
+        commit_branch = target_branch
+
+        # Use Travis pull request target branch if in Travis environment
+        if os.getenv('TRAVIS_BRANCH'):
+            commit_branch = os.getenv('TRAVIS_BRANCH')
+
+        # Commit labeled "WIP" (Work-in-progress) shouldn't end up in master
+        if commit_branch in main_branches and title[0:3] == "WIP":
+            self._add_fail(
+                f"Commit message title '{title}' has a work-in-progress label "
+                "while it's going to master"
+            )
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=DESCRIPTION)


### PR DESCRIPTION
1. if `--target-branch` is set to master/main (it also defaults to it), a warning is shown for commits starting with "WIP"
2. in Travis env, the target branch is read from TRAVIS_BRANCH env var and if it's master/main, show warning for WIPs

The second check provides a way to use this in CI for pull requests.

Depends on #25.